### PR TITLE
libretro: close the VU1 thread before the frontend can, not after

### DIFF
--- a/pcee2-libretro/Libretro.cpp
+++ b/pcee2-libretro/Libretro.cpp
@@ -208,7 +208,25 @@ namespace LibretroHost
 
 	// SPU2 output stream that the frontend pulls samples from in retro_run().
 	// Reads happen while the CPU thread is parked in PumpMessagesOnCPUThread(),
-	// and the ring buffer is SPSC-atomic anyway, so no extra locking is needed.
+	// and the ring buffer itself is SPSC-atomic, so no locking is needed for
+	// steady-state reads/writes against a live stream object.
+	//
+	// That assumption breaks around VMManager::Reset(): SPU2::CreateOutputStream()
+	// (called from hwReset() by way of SPU2::Reset() -> UpdateSampleRate(), or
+	// via ApplySettings()) does `s_output_stream.reset()` then constructs a
+	// brand new stream, and s_audio_stream is just an observer of whichever
+	// object SPU2 currently owns - it isn't updated until the new stream's
+	// constructor runs. Between those two points the old AudioStream is fully
+	// destroyed while s_audio_stream still points at it. retro_run() keeps
+	// getting called on its own schedule the whole time (nothing about
+	// retro_reset() pauses it), so OutputAudio() can - and did - dereference
+	// a freed stream via s_audio_stream mid-teardown. s_audio_stream_mutex
+	// closes that window: OutputAudio() holds it only for the quick
+	// PullFrames() call, and retro_reset() holds it for the full
+	// VMManager::Reset(), so the two can never overlap regardless of which
+	// thread ends up calling what.
+	static std::mutex s_audio_stream_mutex;
+
 	class LibretroAudioStream final : public AudioStream
 	{
 	public:
@@ -1783,20 +1801,26 @@ void retro_reset(void)
 	if (!s_running.load(std::memory_order_acquire))
 		return;
 
-	// Must block: VMManager::Reset() -> hwReset() tears down and recreates
-	// SPU2's output stream, which s_audio_stream just observes (see its
-	// declaration above - "owned by SPU2"). retro_run()'s OutputAudio() reads
-	// through that raw pointer on the frontend thread with no lock, safe only
-	// because the normal per-frame protocol keeps the CPU thread parked while
-	// it does. A fire-and-forget reset breaks that: the frontend thread is
-	// free to call retro_run() again immediately, and can dereference the
-	// stream mid-teardown - PullFrames() then reads/divides by fields of an
-	// object that's being destroyed or was just zeroed, which is exactly what
-	// crashed here (read AV or #DE depending on timing). Blocking until
-	// VMManager::Reset() fully completes guarantees the frontend can't call
-	// retro_run() again until SPU2 has already re-pointed s_audio_stream at a
-	// fresh, valid stream.
-	Host::RunOnCPUThread([]() { VMManager::Reset(); }, true);
+	// s_audio_stream_mutex (see its declaration, above OutputAudio()) is what
+	// actually keeps this safe: it's held for the whole of VMManager::Reset()
+	// here, and OutputAudio() takes the same lock before touching
+	// s_audio_stream, so the two can never run concurrently regardless of
+	// which thread calls retro_run() - and nothing in this codebase promises
+	// that's the same thread that's blocked below.
+	//
+	// block=true is also correct on its own merits (matches ChangeDiscIndex):
+	// it stops retro_reset() from returning - and therefore a second Reset()
+	// or a save-state op from being accepted - while one is still in flight.
+	// But block=true alone was tried first and did not fix the crash this
+	// comment used to describe: it only serializes *this* function against
+	// its own caller, and retro_run() is not called through retro_reset(), so
+	// nothing here was ever able to stop it from running at the same time.
+	Host::RunOnCPUThread(
+		[]() {
+			std::unique_lock lock(s_audio_stream_mutex);
+			VMManager::Reset();
+		},
+		true);
 }
 
 // Translate libretro joypad/analog state into DualShock2 binds. Called at the
@@ -1909,8 +1933,11 @@ static void OutputAudio()
 	static int16_t s16_buffer[MAX_AUDIO_FRAMES_PER_RUN * 2];
 
 	u32 frames = 0;
-	if (s_audio_stream)
-		frames = s_audio_stream->PullFrames(float_buffer, MAX_AUDIO_FRAMES_PER_RUN);
+	{
+		std::unique_lock lock(s_audio_stream_mutex);
+		if (s_audio_stream)
+			frames = s_audio_stream->PullFrames(float_buffer, MAX_AUDIO_FRAMES_PER_RUN);
+	}
 
 	if (frames == 0)
 	{

--- a/pcee2-libretro/Libretro.cpp
+++ b/pcee2-libretro/Libretro.cpp
@@ -60,6 +60,7 @@
 #include "pcsx2/GS/Renderers/Vulkan/VKLibretro.h"
 #include "pcsx2/GS/Renderers/Vulkan/VKLoader.h"
 #include "pcsx2/MTGS.h"
+#include "pcsx2/MTVU.h"
 #include "pcsx2/MemoryTypes.h"
 #include "pcsx2/SIO/Pad/Pad.h"
 #include "pcsx2/SaveState.h"
@@ -1230,6 +1231,21 @@ void retro_deinit(void)
 			s_exit_requested = false;
 		}
 	}
+
+	// MTVU's VU1 thread is a second background thread the core owns, and
+	// nothing has joined it up to this point - the CPU thread above only ever
+	// waits on it (WaitVU()), it never closes it. Left alone, the only thing
+	// that would ever join it is VU_Thread's own destructor, and for the
+	// global `vu1Thread` that lives in this DLL, that destructor only runs at
+	// DLL_PROCESS_DETACH inside FreeLibrary() - under the loader lock. That is
+	// exactly the deadlock class this function was already patched to avoid
+	// for the CPU thread (see the pacing-handshake break above): a frontend
+	// that calls retro_deinit() and then unloads the module (which this one
+	// does, since we report SET_SUPPORT_NO_GAME false) joins the VU1 thread
+	// from within DllMain, and the VU1 thread's own exit can need that same
+	// lock to come back. Close it here instead, while we're still safely
+	// outside FreeLibrary().
+	vu1Thread.Close();
 
 	// Hand the process' fault handling back to the frontend. Nothing of ours
 	// runs from here on, and the frontend unloads this module while it keeps

--- a/pcee2-libretro/Libretro.cpp
+++ b/pcee2-libretro/Libretro.cpp
@@ -278,6 +278,8 @@ namespace LibretroHost
 	{
 		std::unique_ptr<LibretroAudioStream> stream = std::make_unique<LibretroAudioStream>(sample_rate, parameters);
 		stream->Initialize();
+		INFO_LOG("DIAG CreateLibretroAudioStream: old s_audio_stream={} new={} rate={}", static_cast<void*>(s_audio_stream),
+			static_cast<void*>(stream.get()), sample_rate);
 		s_audio_stream = stream.get();
 		s_audio_sample_rate.store(sample_rate, std::memory_order_release);
 		return stream;
@@ -1815,12 +1817,19 @@ void retro_reset(void)
 	// comment used to describe: it only serializes *this* function against
 	// its own caller, and retro_run() is not called through retro_reset(), so
 	// nothing here was ever able to stop it from running at the same time.
+	INFO_LOG("DIAG retro_reset: entering, s_cpu_thread_id-matches={}", std::this_thread::get_id() == s_cpu_thread_id);
 	Host::RunOnCPUThread(
 		[]() {
+			INFO_LOG("DIAG retro_reset lambda: about to lock, s_audio_stream={}", static_cast<void*>(s_audio_stream));
 			std::unique_lock lock(s_audio_stream_mutex);
+			INFO_LOG("DIAG retro_reset lambda: locked, calling VMManager::Reset()");
 			VMManager::Reset();
+			INFO_LOG("DIAG retro_reset lambda: VMManager::Reset() returned, s_audio_stream={}",
+				static_cast<void*>(s_audio_stream));
 		},
 		true);
+	INFO_LOG("DIAG retro_reset: Host::RunOnCPUThread(block=true) returned, s_audio_stream={}",
+		static_cast<void*>(s_audio_stream));
 }
 
 // Translate libretro joypad/analog state into DualShock2 binds. Called at the
@@ -1935,6 +1944,12 @@ static void OutputAudio()
 	u32 frames = 0;
 	{
 		std::unique_lock lock(s_audio_stream_mutex);
+		static void* s_diag_last_ptr = reinterpret_cast<void*>(1); // != nullptr and != any real pointer we'll see first call
+		if (static_cast<void*>(s_audio_stream) != s_diag_last_ptr)
+		{
+			INFO_LOG("DIAG OutputAudio: s_audio_stream changed {} -> {}", s_diag_last_ptr, static_cast<void*>(s_audio_stream));
+			s_diag_last_ptr = static_cast<void*>(s_audio_stream);
+		}
 		if (s_audio_stream)
 			frames = s_audio_stream->PullFrames(float_buffer, MAX_AUDIO_FRAMES_PER_RUN);
 	}

--- a/pcee2-libretro/Libretro.cpp
+++ b/pcee2-libretro/Libretro.cpp
@@ -1013,8 +1013,40 @@ void LibretroHost::CPUThreadMain()
 				VMManager::SetState(VMState::Running);
 				// the frontend paces us through retro_run(); never wall-clock throttle
 				VMManager::SetLimiterMode(LimiterModeType::Unlimited);
-				while (VMManager::GetState() == VMState::Running && s_running.load(std::memory_order_acquire))
+				while (s_running.load(std::memory_order_acquire))
+				{
+					const VMState state = VMManager::GetState();
+					if (state == VMState::Resetting)
+					{
+						// retro_reset() (via Host::RunOnCPUThread) already called
+						// VMManager::Reset() once to get here - that call only
+						// flagged VMState::Resetting and returned, because it ran
+						// while state was Running (see VMManager::Reset()'s own
+						// comment: it exits the rec's tight execution loop first,
+						// then expects to be called again to do the real work).
+						// Calling it again now, with state == Resetting, bypasses
+						// that early-out and actually runs hwReset()/SPU2::Reset()/
+						// etc., ending by flipping state back to Running - exactly
+						// the pattern every other PCSX2 frontend's main loop uses
+						// (see QtHost's `case VMState::Resetting: VMManager::Reset();`).
+						// Without this case here, this loop's condition just saw a
+						// non-Running state and fell through to VMManager::Shutdown()
+						// below - i.e. "Reštart" silently tore the whole VM down
+						// instead of resetting it, out from under retro_run() still
+						// being called every frame by the frontend. This is also why
+						// the lock has to be here and not in retro_reset(): this is
+						// where SPU2's output stream is actually torn down and
+						// recreated, not there.
+						std::unique_lock lock(s_audio_stream_mutex);
+						VMManager::Reset();
+						continue;
+					}
+
+					if (state != VMState::Running)
+						break;
+
 					VMManager::Execute();
+				}
 				VMManager::Shutdown(false);
 			}
 			else
@@ -1801,26 +1833,26 @@ void retro_reset(void)
 	if (!s_running.load(std::memory_order_acquire))
 		return;
 
-	// s_audio_stream_mutex (see its declaration, above OutputAudio()) is what
-	// actually keeps this safe: it's held for the whole of VMManager::Reset()
-	// here, and OutputAudio() takes the same lock before touching
-	// s_audio_stream, so the two can never run concurrently regardless of
-	// which thread calls retro_run() - and nothing in this codebase promises
-	// that's the same thread that's blocked below.
+	// VMManager::Reset() only *requests* a reset from here: called while the
+	// VM is Running (always, since this can only run against a live session),
+	// it just flags VMState::Resetting and returns immediately - see its own
+	// comment ("we tell the rec to exit execution, _then_ reset"). The actual
+	// reset (hwReset(), SPU2::Reset(), ...) only happens once something calls
+	// VMManager::Reset() again while state == Resetting; every other PCSX2
+	// frontend's main loop has a case for that (see QtHost's `case
+	// VMState::Resetting: VMManager::Reset(); continue;`) and drives the real
+	// reset from there. CPUThreadMain() below does the same now - that's
+	// also where s_audio_stream_mutex actually needs to be held (see its
+	// declaration, above OutputAudio()), not here: locking around *this*
+	// call only serializes the flag-set against its own caller, and the real
+	// teardown/rebuild of the audio stream happens later, back in
+	// CPUThreadMain(), on the CPU thread's own schedule.
 	//
-	// block=true is also correct on its own merits (matches ChangeDiscIndex):
-	// it stops retro_reset() from returning - and therefore a second Reset()
-	// or a save-state op from being accepted - while one is still in flight.
-	// But block=true alone was tried first and did not fix the crash this
-	// comment used to describe: it only serializes *this* function against
-	// its own caller, and retro_run() is not called through retro_reset(), so
-	// nothing here was ever able to stop it from running at the same time.
-	Host::RunOnCPUThread(
-		[]() {
-			std::unique_lock lock(s_audio_stream_mutex);
-			VMManager::Reset();
-		},
-		true);
+	// block=true still matters on its own merits (matches ChangeDiscIndex):
+	// it stops retro_reset() from returning - and a second reset or a
+	// save-state op from being accepted - before the request has even been
+	// queued.
+	Host::RunOnCPUThread([]() { VMManager::Reset(); }, true);
 }
 
 // Translate libretro joypad/analog state into DualShock2 binds. Called at the

--- a/pcee2-libretro/Libretro.cpp
+++ b/pcee2-libretro/Libretro.cpp
@@ -1780,8 +1780,23 @@ void retro_unload_game(void)
 
 void retro_reset(void)
 {
-	if (s_running.load(std::memory_order_acquire))
-		Host::RunOnCPUThread([]() { VMManager::Reset(); });
+	if (!s_running.load(std::memory_order_acquire))
+		return;
+
+	// Must block: VMManager::Reset() -> hwReset() tears down and recreates
+	// SPU2's output stream, which s_audio_stream just observes (see its
+	// declaration above - "owned by SPU2"). retro_run()'s OutputAudio() reads
+	// through that raw pointer on the frontend thread with no lock, safe only
+	// because the normal per-frame protocol keeps the CPU thread parked while
+	// it does. A fire-and-forget reset breaks that: the frontend thread is
+	// free to call retro_run() again immediately, and can dereference the
+	// stream mid-teardown - PullFrames() then reads/divides by fields of an
+	// object that's being destroyed or was just zeroed, which is exactly what
+	// crashed here (read AV or #DE depending on timing). Blocking until
+	// VMManager::Reset() fully completes guarantees the frontend can't call
+	// retro_run() again until SPU2 has already re-pointed s_audio_stream at a
+	// fresh, valid stream.
+	Host::RunOnCPUThread([]() { VMManager::Reset(); }, true);
 }
 
 // Translate libretro joypad/analog state into DualShock2 binds. Called at the

--- a/pcee2-libretro/Libretro.cpp
+++ b/pcee2-libretro/Libretro.cpp
@@ -278,8 +278,6 @@ namespace LibretroHost
 	{
 		std::unique_ptr<LibretroAudioStream> stream = std::make_unique<LibretroAudioStream>(sample_rate, parameters);
 		stream->Initialize();
-		INFO_LOG("DIAG CreateLibretroAudioStream: old s_audio_stream={} new={} rate={}", static_cast<void*>(s_audio_stream),
-			static_cast<void*>(stream.get()), sample_rate);
 		s_audio_stream = stream.get();
 		s_audio_sample_rate.store(sample_rate, std::memory_order_release);
 		return stream;
@@ -1817,19 +1815,12 @@ void retro_reset(void)
 	// comment used to describe: it only serializes *this* function against
 	// its own caller, and retro_run() is not called through retro_reset(), so
 	// nothing here was ever able to stop it from running at the same time.
-	INFO_LOG("DIAG retro_reset: entering, s_cpu_thread_id-matches={}", std::this_thread::get_id() == s_cpu_thread_id);
 	Host::RunOnCPUThread(
 		[]() {
-			INFO_LOG("DIAG retro_reset lambda: about to lock, s_audio_stream={}", static_cast<void*>(s_audio_stream));
 			std::unique_lock lock(s_audio_stream_mutex);
-			INFO_LOG("DIAG retro_reset lambda: locked, calling VMManager::Reset()");
 			VMManager::Reset();
-			INFO_LOG("DIAG retro_reset lambda: VMManager::Reset() returned, s_audio_stream={}",
-				static_cast<void*>(s_audio_stream));
 		},
 		true);
-	INFO_LOG("DIAG retro_reset: Host::RunOnCPUThread(block=true) returned, s_audio_stream={}",
-		static_cast<void*>(s_audio_stream));
 }
 
 // Translate libretro joypad/analog state into DualShock2 binds. Called at the
@@ -1944,12 +1935,6 @@ static void OutputAudio()
 	u32 frames = 0;
 	{
 		std::unique_lock lock(s_audio_stream_mutex);
-		static void* s_diag_last_ptr = reinterpret_cast<void*>(1); // != nullptr and != any real pointer we'll see first call
-		if (static_cast<void*>(s_audio_stream) != s_diag_last_ptr)
-		{
-			INFO_LOG("DIAG OutputAudio: s_audio_stream changed {} -> {}", s_diag_last_ptr, static_cast<void*>(s_audio_stream));
-			s_diag_last_ptr = static_cast<void*>(s_audio_stream);
-		}
 		if (s_audio_stream)
 			frames = s_audio_stream->PullFrames(float_buffer, MAX_AUDIO_FRAMES_PER_RUN);
 	}

--- a/pcsx2/GS/Renderers/OpenGL/GLContextWGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLContextWGL.cpp
@@ -296,7 +296,14 @@ bool GLContextWGL::CreatePBuffer(Error* error)
 		wc.lpszClassName = window_class_name;
 		wc.hIconSm = NULL;
 
-		if (!RegisterClassExW(&wc))
+		// window_class_registered is reset to false every time this module is
+		// reloaded (it's a per-instance static), but the class itself was
+		// registered against GetModuleHandle(nullptr) - the host process, not
+		// this module - so it outlives a FreeLibrary()/LoadLibrary() cycle of
+		// this DLL. A second load's registration attempt is therefore expected
+		// to collide with the still-live class from the previous load: that's
+		// not a failure, the class is still perfectly usable.
+		if (!RegisterClassExW(&wc) && GetLastError() != ERROR_CLASS_ALREADY_EXISTS)
 		{
 			Error::SetStringView(error, "(ContextWGL::CreatePBuffer) RegisterClassExW() failed");
 			return false;


### PR DESCRIPTION
Fixes #13.

## Root cause

This core reports `SET_SUPPORT_NO_GAME` false, so RetroArch follows Close
Content with a full core unload: `retro_unload_game()`, then
`retro_deinit()`, then `FreeLibrary()` on the core DLL.

202f05b already made `retro_deinit()` join the CPU/EE thread cleanly. What
it didn't reach is MTVU's `vu1Thread` - a second background thread the core
owns. Nothing in `retro_unload_game()`/`retro_deinit()` ever closes it; the
CPU thread only ever calls `WaitVU()` on it. The only thing that joins it is
`VU_Thread`'s own destructor, and for the global `vu1Thread` living in this
DLL, that destructor runs at `DLL_PROCESS_DETACH` - inside `FreeLibrary()`,
under the loader lock. That's the exact deadlock class 202f05b's own commit
message described, just for a thread that fix didn't cover.

## Repro / verification, on the machine that reported this

Windows 11, RetroArch 1.22.2, Gran Turismo 3 (PS2, CHD, MTVU enabled per
the boot log).

**Before this fix** (commit eb4599b8, i.e. current `libretro` HEAD, which
already has 202f05b): launched content, let it run, used the Quick Menu's
"Close Content" through the real UI. Teardown logged as far as
`Unloading core...` -> `Releasing host memory for virtual systems...` ->
`Unloading core symbols...` -> `Saved core options file...`, then froze
there permanently - RetroArch never returned to the menu, one thread kept
burning CPU indefinitely. A full minidump + WinDbg `~*kv` showed the main
thread and a `pcee2_libretro.dll` thread both parked in
`WaitForSingleObjectEx`, with `lm v m pcee2_libretro` confirming the module
was still loaded and mapped - consistent with the DLL never finishing
`FreeLibrary()`.

**With this fix**: built from CI, installed the core, same repro steps
(actual Quick Menu -> Close Content, not just the network command interface
- `CLOSE_CONTENT` over the network command port had no effect at all in
either build, which is a separate, milder oddity worth a look sometime but
isn't this bug). RetroArch's UI stays responsive throughout, and polling
confirmed `pcee2_libretro.dll` fully unloads (drops out of the process'
module list) within ~14 seconds of pressing Close Content - no hang, no
force-kill needed.

## The fix

Close `vu1Thread` explicitly in `retro_deinit()`, after the CPU thread has
already been joined (so nothing is still feeding its ring buffer) and
before the frontend gets anywhere near `FreeLibrary()` - the same shape as
202f05b's fix, for the other thread.
