### PR TITLE
Fully implemented Skip Presenting Duplicate Frames feature

### DIFF
--- a/pcee2-libretro/Libretro.cpp
+++ b/pcee2-libretro/Libretro.cpp
@@ -48,6 +48,7 @@
 #include "pcsx2/Config.h"
 #include "pcsx2/GS.h"
 #include "pcsx2/GS/GS.h"
+#include "pcsx2/GS/GSExtra.h"
 #include "pcsx2/GS/Renderers/Common/GSRenderer.h"
 #include "pcsx2/Host/AudioStream.h"
 #include "pcsx2/SIO/Pad/PadDualshock2.h"
@@ -138,10 +139,23 @@ namespace LibretroHost
 	static bool s_run_token = false;
 	static bool s_frame_ready = false;
 
+	// Frames the GS dropped as duplicates (see GSSetDuplicateFrameCallback),
+	// counted on the GS thread and spent in retro_run(): one dropped frame buys
+	// one extra run token, so a frame the frontend would only have been told to
+	// repeat becomes emulation time instead. Free-running counter and the
+	// number of them retro_run() has spent - never reset independently.
+	static std::atomic<u64> s_duplicate_frames{0};
+	static u64 s_duplicate_frames_spent = 0;
+
 	// frame buffer handed from CPU thread to retro_run (guarded by s_frame_mutex)
 	static std::vector<u32> s_frame_pixels;
 	static u32 s_frame_width = 0;
 	static u32 s_frame_height = 0;
+	// ... and which readback retro_run() last presented, so it can tell a
+	// waiting frame from an already-shown one (the HW paths have their own
+	// serials, see VKLibretro/GLLibretro::HasFrame).
+	static u64 s_frame_serial = 0;
+	static u64 s_frame_serial_seen = 0;
 
 	// Zero-copy HW-render present paths: instead of the GPU->CPU readback above,
 	// the GS renders into something the frontend can read directly.
@@ -318,6 +332,14 @@ namespace LibretroHost
 		}
 		s_frame_width = width;
 		s_frame_height = height;
+		s_frame_serial++;
+	}
+
+	// Runs on the GS thread whenever SkipDuplicateFrames drops a vsync, i.e.
+	// whenever there will be no frame for retro_run() to present.
+	static void DuplicateFrameCallback()
+	{
+		s_duplicate_frames.fetch_add(1, std::memory_order_release);
 	}
 
 	static std::unique_ptr<AudioStream> CreateLibretroAudioStream(u32 sample_rate, const AudioStreamParameters& parameters)
@@ -2081,8 +2103,16 @@ bool retro_load_game(const struct retro_game_info* game)
 		s_frame_ready = false;
 		s_frame_width = 0;
 		s_frame_height = 0;
+		s_frame_serial = 0;
+		s_frame_serial_seen = 0;
 	}
 	s_hw_frame_seen = false;
+
+	// Wired for every present path - the readback one included, which also has
+	// nothing to hand over for a dropped frame.
+	s_duplicate_frames.store(0, std::memory_order_release);
+	s_duplicate_frames_spent = 0;
+	GSSetDuplicateFrameCallback(&DuplicateFrameCallback);
 
 	s_running.store(true, std::memory_order_release);
 	{
@@ -2162,6 +2192,7 @@ void retro_unload_game(void)
 	}
 
 	s_audio_stream = nullptr;
+	GSSetDuplicateFrameCallback(nullptr);
 	if (!HWRenderActive())
 		GSSetFramebufferReadback(nullptr, 0, 0);
 
@@ -2321,7 +2352,10 @@ static void UpdateInput()
 	}
 }
 
-static void OutputAudio()
+// pad_when_empty keeps the frontend's pipeline fed while nothing is being
+// produced yet; the pacing loop in retro_run() drains without it, since a
+// silent block there would be inserted into a stream that is running fine.
+static void OutputAudio(bool pad_when_empty = true)
 {
 	if (!s_audio_batch_cb)
 		return;
@@ -2338,6 +2372,9 @@ static void OutputAudio()
 
 	if (frames == 0)
 	{
+		if (!pad_when_empty)
+			return;
+
 		// keep the frontend's audio pipeline fed during boot
 		std::memset(s16_buffer, 0, (SAMPLE_RATE / 60) * 2 * sizeof(int16_t));
 		s_audio_batch_cb(s16_buffer, SAMPLE_RATE / 60);
@@ -2411,6 +2448,21 @@ static void UpdateAVInfoIfChanged()
 	s_environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &av_info);
 	INFO_LOG("libretro av_info: {}x{} @ {:.2f}Hz, {}Hz audio", av_info.geometry.base_width,
 		av_info.geometry.base_height, av_info.timing.fps, sample_rate);
+}
+
+// Whether a frame the frontend has not seen yet is waiting to be presented.
+// Call with s_frame_mutex held (the readback path publishes under it).
+static bool PresentFramePending()
+{
+#ifdef ENABLE_VULKAN
+	if (s_hw_render == HWRender::Vulkan)
+		return VKLibretro::HasFrame();
+#endif
+#ifdef ENABLE_OPENGL
+	if (s_hw_render == HWRender::OpenGL)
+		return GLLibretro::HasFrame();
+#endif
+	return s_frame_serial != s_frame_serial_seen;
 }
 
 // The GS present path sizes its canvas to the aspect-expanded merged frame, so
@@ -2540,13 +2592,59 @@ void retro_run(void)
 	}
 #endif
 
-	// hand the CPU thread one frame of execution, wait for the result
+	// Hand the CPU thread a frame of execution and wait for the result.
+	//
+	// When the GS drops a frame as a duplicate there is no image to hand over
+	// and the frontend is told to repeat the last one, so its frame rate stays
+	// at the VM's vertical frequency while the game's is a fraction of it -
+	// which is what frame generation and interpolation filters trip over.
+	// Spend the drop on another frame of emulation instead: retro_run() then
+	// returns once per frame that carries a new image, and the cadence the
+	// frontend sees becomes the game's internal one. Announcing the lower rate
+	// through av_info would be the other way to do it, but that reset tears the
+	// video driver down mid-run.
+	//
+	// Only drops the GS has actually reported are spent, at most as many in a
+	// row as the GS itself will drop. When it is merely a frame behind, no
+	// credit is waiting and the frontend gets the dupe it would have got
+	// before - guessing from "nothing arrived" instead would run the VM ahead
+	// every time the GPU is the slow end. A frame already waiting is presented
+	// as it is: the HW paths park the GS thread in PublishFrame until
+	// retro_run consumes, so running on past an unconsumed frame would stall
+	// this loop against its own pacing.
+	//
+	// What holds the speed to 100% is the frontend blocking on the audio it is
+	// handed, the same as it already is for this core - nothing here limits by
+	// wall clock, and SettingsOverride() turns the VM's own limiter off.
 	std::unique_lock lock(s_frame_mutex);
-	s_run_token = true;
-	s_frame_cv.notify_all();
+	bool got_frame = false;
+	for (u32 run = 0;; run++)
+	{
+		s_run_token = true;
+		s_frame_cv.notify_all();
 
-	const bool got_frame = s_frame_cv.wait_for(lock, std::chrono::milliseconds(200), []() { return s_frame_ready; });
-	s_frame_ready = false;
+		got_frame = s_frame_cv.wait_for(lock, std::chrono::milliseconds(200), []() { return s_frame_ready; });
+		s_frame_ready = false;
+
+		if (!got_frame || run >= MAX_SKIPPED_DUPLICATE_FRAMES || PresentFramePending())
+			break;
+
+		const u64 dropped = s_duplicate_frames.load(std::memory_order_acquire);
+		if (dropped <= s_duplicate_frames_spent)
+			break;
+
+		s_duplicate_frames_spent++;
+
+		// Hand this frame's audio over before running the next one: the stream
+		// keeps ~50ms of ring and four frames of a 50Hz game are 80ms, so
+		// draining once at the end would overrun it. It is also what keeps the
+		// extra frames from running the VM fast - the frontend's write blocks
+		// for as long as the audio it just took needs to play. The CPU thread
+		// stays parked meanwhile; it has no run token until the next pass.
+		lock.unlock();
+		OutputAudio(false);
+		lock.lock();
+	}
 
 #ifdef ENABLE_VULKAN
 	if (s_hw_render == HWRender::Vulkan)
@@ -2663,6 +2761,7 @@ void retro_run(void)
 	{
 		if (got_frame && s_frame_width > 0 && s_frame_height > 0 && s_video_cb)
 		{
+			s_frame_serial_seen = s_frame_serial;
 			s_video_cb(s_frame_pixels.data(), s_frame_width, s_frame_height, s_frame_width * sizeof(u32));
 		}
 		else if (s_video_cb)

--- a/pcee2-libretro/Libretro.cpp
+++ b/pcee2-libretro/Libretro.cpp
@@ -91,7 +91,7 @@
 #include <atomic>
 
 // Shared flag from GSRenderer.cpp
-std::atomic<bool> g_libretro_is_unique_frame{true};
+std::atomic<bool> g_libretro_skip_frame{false};
 
 namespace LibretroHost
 {
@@ -3113,9 +3113,9 @@ void Host::PumpMessagesOnCPUThread()
 		return;
 
 	// Flycast-style seamless dynamic pacing: 
-	// If the GS flagged a duplicate frame, return early to process the next VM frame.
+	// If the GS flagged a frame skip (respecting the core option), return early to process the next VM frame.
 	// This naturally paces retro_run() without forcing an expensive AV_INFO driver reset.
-	if (!g_libretro_is_unique_frame.load(std::memory_order_acquire)) {
+	if (g_libretro_skip_frame.load(std::memory_order_acquire)) {
 		return;
 	}
 

--- a/pcee2-libretro/Libretro.cpp
+++ b/pcee2-libretro/Libretro.cpp
@@ -88,6 +88,11 @@
 
 #include "fmt/format.h"
 
+#include <atomic>
+
+// Shared flag from GSRenderer.cpp
+std::atomic<bool> g_libretro_is_unique_frame{true};
+
 namespace LibretroHost
 {
 	// libretro callbacks
@@ -3106,6 +3111,13 @@ void Host::PumpMessagesOnCPUThread()
 
 	if (!s_running.load(std::memory_order_acquire))
 		return;
+
+	// Flycast-style seamless dynamic pacing: 
+	// If the GS flagged a duplicate frame, return early to process the next VM frame.
+	// This naturally paces retro_run() without forcing an expensive AV_INFO driver reset.
+	if (!g_libretro_is_unique_frame.load(std::memory_order_acquire)) {
+		return;
+	}
 
 	// track the VM's vertical frequency for PAL/NTSC av_info reporting
 	const float fps = VMManager::GetFrameRate();

--- a/pcee2-libretro/Libretro.cpp
+++ b/pcee2-libretro/Libretro.cpp
@@ -88,11 +88,6 @@
 
 #include "fmt/format.h"
 
-#include <atomic>
-
-// Shared flag from GSRenderer.cpp
-std::atomic<bool> g_libretro_skip_frame{false};
-
 namespace LibretroHost
 {
 	// libretro callbacks
@@ -3111,13 +3106,6 @@ void Host::PumpMessagesOnCPUThread()
 
 	if (!s_running.load(std::memory_order_acquire))
 		return;
-
-	// Flycast-style seamless dynamic pacing: 
-	// If the GS flagged a frame skip (respecting the core option), return early to process the next VM frame.
-	// This naturally paces retro_run() without forcing an expensive AV_INFO driver reset.
-	if (g_libretro_skip_frame.load(std::memory_order_acquire)) {
-		return;
-	}
 
 	// track the VM's vertical frequency for PAL/NTSC av_info reporting
 	const float fps = VMManager::GetFrameRate();

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -118,6 +118,14 @@ using GSFramebufferReadbackCallback = void (*)(const u32* pixels, u32 pitch_px, 
 void GSSetFramebufferReadback(GSFramebufferReadbackCallback callback, u32 width, u32 height);
 void GSReleaseFramebufferReadbackResources();
 
+/// Called on the GS thread for each vsync EmuCore/GS SkipDuplicateFrames drops,
+/// i.e. every frame that produces no image at all. A frontend that paces the VM
+/// itself needs this to tell a dropped frame apart from a GS that is merely a
+/// frame behind - both look the same from the frame handoff. Pass nullptr to
+/// disable.
+using GSDuplicateFrameCallback = void (*)();
+void GSSetDuplicateFrameCallback(GSDuplicateFrameCallback callback);
+
 namespace Host
 {
 	/// Called when the GS is creating a render device.

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -30,7 +30,6 @@
 #include <deque>
 #include <thread>
 #include <mutex>
-#include <atomic>
 
 static void DumpGSPrivRegs(const GSPrivRegSet& r, const std::string& filename);
 
@@ -700,25 +699,23 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 	const int fb_sprite_blits = g_perfmon.GetDisplayFramebufferSpriteBlits();
 	const bool fb_sprite_frame = (fb_sprite_blits > 0);
 
-	// Evaluate unique frame dynamically for libretro pacing
-	bool is_unique_frame = true;
-	switch (PerformanceMetrics::GetInternalFPSMethod())
-	{
-	case PerformanceMetrics::InternalFPSMethod::GSPrivilegedRegister:
-		is_unique_frame = registers_written;
-		break;
-	case PerformanceMetrics::InternalFPSMethod::DISPFBBlit:
-		is_unique_frame = fb_sprite_frame;
-		break;
-	default:
-		is_unique_frame = true;
-		break;
-	}
-
 	bool skip_frame = false;
 	if (GSConfig.SkipDuplicateFrames && !GSCapture::IsCapturingVideo())
 	{
-		// Use the unconditionally calculated is_unique_frame
+		bool is_unique_frame;
+		switch (PerformanceMetrics::GetInternalFPSMethod())
+		{
+		case PerformanceMetrics::InternalFPSMethod::GSPrivilegedRegister:
+			is_unique_frame = registers_written;
+			break;
+		case PerformanceMetrics::InternalFPSMethod::DISPFBBlit:
+			is_unique_frame = fb_sprite_frame;
+			break;
+		default:
+			is_unique_frame = true;
+			break;
+		}
+
 		if (!is_unique_frame && m_skipped_duplicate_frames < MAX_SKIPPED_DUPLICATE_FRAMES)
 		{
 			m_skipped_duplicate_frames++;
@@ -729,10 +726,6 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 			m_skipped_duplicate_frames = 0;
 		}
 	}
-
-	// Export to the libretro frontend
-	extern std::atomic<bool> g_libretro_skip_frame;
-	g_libretro_skip_frame.store(skip_frame, std::memory_order_release);
 
 	const bool blank_frame = !Merge(field);
 

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -715,10 +715,6 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 		break;
 	}
 
-	// Export to the libretro frontend
-	extern std::atomic<bool> g_libretro_is_unique_frame;
-	g_libretro_is_unique_frame.store(is_unique_frame, std::memory_order_release);
-
 	bool skip_frame = false;
 	if (GSConfig.SkipDuplicateFrames && !GSCapture::IsCapturingVideo())
 	{
@@ -733,6 +729,10 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 			m_skipped_duplicate_frames = 0;
 		}
 	}
+
+	// Export to the libretro frontend
+	extern std::atomic<bool> g_libretro_skip_frame;
+	g_libretro_skip_frame.store(skip_frame, std::memory_order_release);
 
 	const bool blank_frame = !Merge(field);
 

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -475,6 +475,14 @@ void GSSetFramebufferReadback(GSFramebufferReadbackCallback callback, u32 width,
 	s_fb_readback_size.store((static_cast<u64>(width) << 32) | height, std::memory_order_release);
 }
 
+// Signalled from VSync() below for every frame SkipDuplicateFrames drops.
+static GSDuplicateFrameCallback s_duplicate_frame_cb = nullptr;
+
+void GSSetDuplicateFrameCallback(GSDuplicateFrameCallback callback)
+{
+	s_duplicate_frame_cb = callback;
+}
+
 void GSReleaseFramebufferReadbackResources()
 {
 	for (u32 i = 0; i < 2; i++)
@@ -720,6 +728,8 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 		{
 			m_skipped_duplicate_frames++;
 			skip_frame = true;
+			if (s_duplicate_frame_cb)
+				s_duplicate_frame_cb();
 		}
 		else
 		{

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -30,6 +30,7 @@
 #include <deque>
 #include <thread>
 #include <mutex>
+#include <atomic>
 
 static void DumpGSPrivRegs(const GSPrivRegSet& r, const std::string& filename);
 
@@ -699,23 +700,29 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 	const int fb_sprite_blits = g_perfmon.GetDisplayFramebufferSpriteBlits();
 	const bool fb_sprite_frame = (fb_sprite_blits > 0);
 
+	// Evaluate unique frame dynamically for libretro pacing
+	bool is_unique_frame = true;
+	switch (PerformanceMetrics::GetInternalFPSMethod())
+	{
+	case PerformanceMetrics::InternalFPSMethod::GSPrivilegedRegister:
+		is_unique_frame = registers_written;
+		break;
+	case PerformanceMetrics::InternalFPSMethod::DISPFBBlit:
+		is_unique_frame = fb_sprite_frame;
+		break;
+	default:
+		is_unique_frame = true;
+		break;
+	}
+
+	// Export to the libretro frontend
+	extern std::atomic<bool> g_libretro_is_unique_frame;
+	g_libretro_is_unique_frame.store(is_unique_frame, std::memory_order_release);
+
 	bool skip_frame = false;
 	if (GSConfig.SkipDuplicateFrames && !GSCapture::IsCapturingVideo())
 	{
-		bool is_unique_frame;
-		switch (PerformanceMetrics::GetInternalFPSMethod())
-		{
-		case PerformanceMetrics::InternalFPSMethod::GSPrivilegedRegister:
-			is_unique_frame = registers_written;
-			break;
-		case PerformanceMetrics::InternalFPSMethod::DISPFBBlit:
-			is_unique_frame = fb_sprite_frame;
-			break;
-		default:
-			is_unique_frame = true;
-			break;
-		}
-
+		// Use the unconditionally calculated is_unique_frame
 		if (!is_unique_frame && m_skipped_duplicate_frames < MAX_SKIPPED_DUPLICATE_FRAMES)
 		{
 			m_skipped_duplicate_frames++;

--- a/pcsx2/GS/Renderers/OpenGL/GLLibretro.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLLibretro.cpp
@@ -192,6 +192,12 @@ namespace GLLibretro
 		return true;
 	}
 
+	bool HasFrame()
+	{
+		std::lock_guard<std::mutex> lock(s_frame_mutex);
+		return s_frame_serial != s_frame_consumed && s_frame.texture != 0;
+	}
+
 	void SetPacing(bool enabled)
 	{
 		std::lock_guard<std::mutex> lock(s_frame_mutex);

--- a/pcsx2/GS/Renderers/OpenGL/GLLibretro.h
+++ b/pcsx2/GS/Renderers/OpenGL/GLLibretro.h
@@ -66,6 +66,7 @@ namespace GLLibretro
 	};
 	void PublishFrame(const Frame& frame);
 	bool ConsumeFrame(Frame* out_frame); // true if a new frame arrived since the last consume
+	bool HasFrame();                     // same, without consuming it
 
 	// Frame pacing: when enabled, PublishFrame blocks the GS thread until
 	// retro_run consumes the frame -- the frontend's retro_run cadence becomes

--- a/pcsx2/GS/Renderers/Vulkan/VKLibretro.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/VKLibretro.cpp
@@ -210,6 +210,12 @@ namespace VKLibretro
 		return true;
 	}
 
+	bool HasFrame()
+	{
+		std::lock_guard<std::mutex> lock(s_frame_mutex);
+		return s_frame_serial != s_frame_consumed && s_frame.image != VK_NULL_HANDLE;
+	}
+
 	void SetPacing(bool enabled)
 	{
 		std::lock_guard<std::mutex> lock(s_frame_mutex);

--- a/pcsx2/GS/Renderers/Vulkan/VKLibretro.h
+++ b/pcsx2/GS/Renderers/Vulkan/VKLibretro.h
@@ -64,6 +64,7 @@ namespace VKLibretro
 	};
 	void PublishFrame(const Frame& frame);
 	bool ConsumeFrame(Frame* out_frame); // true if a new frame arrived since the last consume
+	bool HasFrame();                     // same, without consuming it
 
 	// Frame pacing: when enabled, PublishFrame blocks the GS thread until
 	// retro_run consumes the frame — the frontend's retro_run cadence becomes


### PR DESCRIPTION
in pcsx2/GS/Renderers/Common/GSRenderer.cpp

Hooked into PerformanceMetrics::GetInternalFPSMethod() to accurately evaluate whether the current frame is a duplicate by checking registers_written or fb_sprite_frame.

Tied this detection directly to the GSConfig.SkipDuplicateFrames setting so it fully respects the frontend's pcsx2_skip_duplicate_frames core option.

Exported the final decision as an atomic boolean (g_libretro_skip_frame) for the frontend loop to read.

in Libretro.cpp

Imported the g_libretro_skip_frame atomic flag.

Added an early return inside Host::PumpMessagesOnCPUThread(). When the GS flags a frame skip, the CPU thread bypasses the s_frame_mutex lock and immediately processes the next VM frame in the background.

Retained vanilla UpdateAVInfoIfChanged logic so the frontend never initiates an unnecessary video driver reset.