### PR TITLE
Add no-content BIOS boot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This project is not affiliated with or endorsed by the PCSX2 team.
 | Multitap (up to 8 controllers) | ✅ core option |
 | Lightgun (GunCon 2 via USB) | ✅ core option, aimed by frontend lightgun/mouse |
 | Other USB devices (wheels, mic, EyeToy) | ❌ not wired up |
+| Start Core without content | ✅ opens the PS2 BIOS / System Menu and Memory Card Browser |
 | Content reload / Close Content | ✅ core survives RetroArch's deinit/init cycles |
 | Windows x64 build (MSVC, via CI) | ✅ community-tested (WRC 4, GTA SA, Killzone on Vulkan) |
 | macOS x86_64 build (via CI) | ⚠️ compiles + links, untested — feedback welcome |
@@ -68,7 +69,7 @@ workflow.
 1. Put a PS2 BIOS dump into `<retroarch system dir>/pcsx2/bios/`.
 2. Optional: copy the `resources` directory from a PCSX2 installation of the same version (or from `bin/resources` of this repo) to `<retroarch system dir>/pcsx2/resources/`. The shaders and fonts the core cannot start without, and the `GameIndex.yaml` game database that carries the per-game fixes, are all compiled into it, so this only adds the remaining optional files; `PCEE2_EXTERNAL_RESOURCES=1` makes the on-disk copies win over the built-in ones, which is how you use a newer game database than the one the core was built with.
 3. For built-in game patches (including the widescreen / no-interlacing options), download [`patches.zip`](https://github.com/PCSX2/pcsx2_patches/releases/latest/download/patches.zip) into `<retroarch system dir>/pcsx2/resources/patches.zip`.
-4. Load a disc image (`.iso`, `.chd`, `.cso`, `.gz`, `.bin`, `.mdf`, `.nrg`, `.elf`) with the core.
+4. Start the core without content to open the PS2 BIOS / System Menu, or load a disc image (`.iso`, `.chd`, `.cso`, `.gz`, `.bin`, `.mdf`, `.nrg`, `.elf`) with the core.
 5. Optional: copy your standalone `PCSX2.ini` to `<retroarch system dir>/pcsx2/inis/PCSX2.ini` — the core adopts its emulation settings (EmuCore, speed hacks, CPU, GS, game fixes, memory cards, DEV9 network/HDD) as the baseline. Core options still override their respective settings.
 
 Memory cards, savestates metadata, cache, etc. live under

--- a/pcee2-libretro/Libretro.cpp
+++ b/pcee2-libretro/Libretro.cpp
@@ -1551,7 +1551,7 @@ void retro_set_environment(retro_environment_t cb)
 {
 	s_environ_cb = cb;
 
-	bool no_game = false;
+	bool no_game = true;
 	cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &no_game);
 
 	retro_log_callback log_cb{};
@@ -1667,8 +1667,7 @@ void retro_deinit(void)
 	// DLL_PROCESS_DETACH inside FreeLibrary() - under the loader lock. That is
 	// exactly the deadlock class this function was already patched to avoid
 	// for the CPU thread (see the pacing-handshake break above): a frontend
-	// that calls retro_deinit() and then unloads the module (which this one
-	// does, since we report SET_SUPPORT_NO_GAME false) joins the VU1 thread
+	// that calls retro_deinit() and then unloads the module joins the VU1 thread
 	// from within DllMain, and the VU1 thread's own exit can need that same
 	// lock to come back. Close it here instead, while we're still safely
 	// outside FreeLibrary().
@@ -1993,13 +1992,20 @@ static void RegisterDiskControl()
 	s_environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE, (void*)&legacy);
 }
 
-// Fills the disc list from whatever the frontend loaded and returns the image
-// to boot, or an empty string if there is nothing bootable in it.
-static std::string BuildDiscList(const char* content_path)
+// Clears only the libretro-facing disc list state. PCSX2's CDVD/NoDisc state
+// remains owned by VMManager and is intentionally not touched here.
+static void ResetDiscList()
 {
 	s_discs.clear();
 	s_disc_index = 0;
 	s_disc_ejected = false;
+}
+
+// Fills the disc list from whatever the frontend loaded and returns the image
+// to boot, or an empty string if there is nothing bootable in it.
+static std::string BuildDiscList(const char* content_path)
+{
+	ResetDiscList();
 
 	if (StringUtil::compareNoCase(Path::GetExtension(content_path), "m3u"))
 	{
@@ -2044,7 +2050,8 @@ static std::string BuildDiscList(const char* content_path)
 
 bool retro_load_game(const struct retro_game_info* game)
 {
-	if (!game || !game->path)
+	const bool no_content = (game == nullptr);
+	if (!no_content && (!game->path || game->path[0] == '\0'))
 		return false;
 
 	enum retro_pixel_format fmt = RETRO_PIXEL_FORMAT_XRGB8888;
@@ -2219,9 +2226,16 @@ bool retro_load_game(const struct retro_game_info* game)
 	s_environ_cb(RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE, &s_rumble_interface);
 
 	s_boot_params = VMBootParameters();
-	s_boot_params.filename = BuildDiscList(game->path);
-	if (s_boot_params.filename.empty())
-		return false;
+	if (no_content)
+	{
+		ResetDiscList();
+	}
+	else
+	{
+		s_boot_params.filename = BuildDiscList(game->path);
+		if (s_boot_params.filename.empty())
+			return false;
+	}
 
 	RegisterDiskControl();
 

--- a/pcee2-libretro/pcee2_libretro.info
+++ b/pcee2-libretro/pcee2_libretro.info
@@ -15,7 +15,7 @@ systemid = "playstation2"
 
 # Libretro Features
 database = "Sony - PlayStation 2"
-supports_no_game = "false"
+supports_no_game = "true"
 savestate = "true"
 savestate_features = "basic"
 cheats = "false"


### PR DESCRIPTION
## Description of Changes

Adds support for starting PCEE2 without content, allowing RetroArch's **Start Core** action to boot the PS2 BIOS / System Menu.

- Accepts no-content launches through the libretro API
- Reuses PCSX2's existing BIOS / NoDisc boot path
- Keeps the existing memory card core options available while the BIOS is running

## Rationale behind Changes

PCEE2 already supports the PS2 BIOS and memory cards, but the libretro frontend did not allow the core to be started without loading game content.

This makes the PS2 System Menu and memory card browser accessible directly from RetroArch.

## Suggested Testing Steps

1. Load the PCEE2 core without selecting content.
2. Select **Start Core** and verify that the PS2 BIOS / System Menu appears.
3. Open the PS2 memory card browser and verify that configured memory cards are detected.
4. Change the selected memory card from RetroArch Core Options while the BIOS is running and verify that the new card is detected.
5. Verify that normal PS2 game content still boots normally.

Tested on Android arm64-v8a with:
- PS2 BIOS / System Menu boot
- Memory card read, runtime switching, copy/write, and delete
- Normal PS2 ISO boot

## Follow-up

The distributed PCEE2 core info currently has `supports_no_game = "false"`.

After this PR is merged, I will submit a separate follow-up PR to `libretro-super` to set `supports_no_game = "true"` so RetroArch's **Start Core** action is exposed through the distributed core info.